### PR TITLE
Remove empty dependee sets (+ add cross-env)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   ],
   "scripts": {
     "test": "yarn build && yarn test:dev && yarn test:minified",
-    "test:minified": "KAIKU_VERSION=minified jest --coverage",
-    "test:dev": "KAIKU_VERSION=development jest --coverage",
+    "test:minified": "cross-env KAIKU_VERSION=minified jest --coverage",
+    "test:dev": "cross-env KAIKU_VERSION=development jest --coverage",
     "typings": "tsc --project tsconfig.json",
     "build": "rm -rf dist/ && node build.js",
     "lint": "eslint src/*",
@@ -30,6 +30,7 @@
     "@babel/preset-env": "^7.14.7",
     "@typescript-eslint/eslint-plugin": "^4.28.3",
     "@typescript-eslint/parser": "^4.28.3",
+    "cross-env": "^7.0.3",
     "esbuild": "^0.12.15",
     "eslint": "^7.30.0",
     "jest": "^27.0.6",

--- a/src/kaiku.ts
+++ b/src/kaiku.ts
@@ -358,6 +358,9 @@ const createState = <StateT extends object>(
         const dependees = keyToDependees.get(key)
         assert?.(dependees)
         dependees.delete(dependee.id_)
+        if (dependees.size === 0) {
+          keyToDependees.delete(key)
+        }
       }
     }
 


### PR DESCRIPTION
Churning through a large amount of dependees without removing the empty sets grows the map without bound. This PR removes sets from the map when they reach zero dependees.

There is a risk that this pessimizes some use cases, an alternative implementation would be to cull the list when it grows too big, eg. every time the size doubles.

EDIT: Oh, and this also adds `cross-env` since this was developed on Windows.