### PR TITLE
Fix edge case in isNewKeyForTarget

### DIFF
--- a/src/kaiku.ts
+++ b/src/kaiku.ts
@@ -460,7 +460,7 @@ const createState = <StateT extends object>(
 
       set(target, _key, value) {
         const key = _key as keyof T
-        const isNewKeyForTarget = typeof target[key] === 'undefined'
+        const isNewKeyForTarget = !(key in target)
 
         if (
           !(isArray && key === 'length') &&

--- a/test/kaiku.spec.jsx
+++ b/test/kaiku.spec.jsx
@@ -998,4 +998,32 @@ describe('kaiku', () => {
     await nextTick()
     expect(rootNode.innerHTML).toMatchSnapshot()
   })
+
+  it('should not rerender a component depending on Object.keys unless the keys actually change', async () => {
+    const state = createState({
+      obj: { a: undefined },
+    })
+
+    const reRenderCounter = jest.fn()
+
+    const App = () => {
+      reRenderCounter()
+      const keys = Object.keys(state.obj)
+
+      return (
+        <div>
+          {keys.map((key) => (
+            <span>{key}</span>
+          ))}
+        </div>
+      )
+    }
+
+    render(<App />, rootNode, state)
+    expect(reRenderCounter).toHaveBeenCalledTimes(1)
+
+    state.obj.a = 'foo'
+    await nextTick()
+    expect(reRenderCounter).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
isNewKeyForTarget is used to notify watchers
of the target object that depend on e.g. the
Object.keys(target) value.

The previous implementation of this check used
`typeof target[key] === "undefined"`, which registers a false positive when `key` exists in the object,
but has the literal value `undefined`.

Instead we can use `!(key in target)` to prevent
unwanted rerenders in this case.