### PR TITLE
Restore input checked attribute special case

### DIFF
--- a/src/kaiku.ts
+++ b/src/kaiku.ts
@@ -1168,6 +1168,12 @@ const updateHtmlElementInstance = (
           })
           continue
         }
+        case 'checked': {
+          lazy(instance, nextProps[key] ?? '', (value) => {
+            ;(instance.element_ as HTMLInputElement).checked = Boolean(value)
+          })
+          continue
+        }
         case 'className': {
           lazy(instance, nextProps[key], (value) => {
             ;(instance.element_.className as any) = stringifyClassNames(


### PR DESCRIPTION
Turns out the DOM is annoying and `removeAttribute("checked")` does remove the `checked` attribute but HTML latches onto user input state if the checkbox is toggled manually.

Demo in the [playground](https://kaiku.dev/playground.html):

```jsx
export default function StickyCheckbox() {
  const state = useState({ checked: true })
  return <>
      <input type="checkbox" checked={state.checked} />
      <button onClick={() => { state.checked = false; }}>Reset</button>
  </>
}
```

1. Observe that the reset button works correctly if you don't touch the checkbox
2. Toggle the checkbox manually off/on
3. Observe that the reset button does not work anymore

It's possible that it's required for option `selected` as well.