### PR TITLE
Fix JSX TypeScript type declarations

### DIFF
--- a/jsx-runtime.d.ts
+++ b/jsx-runtime.d.ts
@@ -1,13 +1,13 @@
-import { DefaultProps, NodeDescriptor } from './dist/kaiku'
+import { DefaultProps, Child, NodeDescriptor } from './dist/kaiku'
 
 declare namespace JSX {
   type Element<T extends DefaultProps> = NodeDescriptor<T>
   type ArrayElement = Element<any>[]
   interface FunctionElement<T extends DefaultProps> {
-    (props: T): Element<T>
+    (props: T): Child
   }
   interface ElementClass<T extends DefaultProps> {
-    render(props: any): Element<T>
+    render(props: T): Child
   }
   type ElementChildrenAttribute = {
     children: any

--- a/src/kaiku.ts
+++ b/src/kaiku.ts
@@ -51,11 +51,10 @@ type HtmlElementProperties = Record<string, any> & {
 }
 
 export type DefaultProps = Record<string, any>
-export type WithIntrinsicProps<T extends DefaultProps> = T extends {
-  children: any
+export type WithIntrinsicProps<T extends DefaultProps> = T & {
+  children?: Child | Children
+  key?: string
 }
-  ? T
-  : T & { children?: Child | Children }
 type LazyProperty<T> = T | (() => T)
 
 type ClassComponentDescriptor<


### PR DESCRIPTION
- Allow returning arbitrary Child from function/class render
- Add key to WithIntrinsicProps
- Remove unnecessary ternary logic to preserve user's children type